### PR TITLE
Allow [attr] to match attr for requireSpecificAttributes

### DIFF
--- a/lib/rules/require-specific-attributes.js
+++ b/lib/rules/require-specific-attributes.js
@@ -89,7 +89,10 @@ module.exports.prototype = {
         if (hasAttributes) {
           requiredAttributes.forEach(function (attribute) {
             if (attributeNames.indexOf(attribute.toLowerCase()) === -1) {
-              errors.add('Tag "' + tag + '" must have attribute "' + attribute + '"', lineNumber, columnNumber);
+              var bracketed = '[' + attribute.toLowerCase() + ']';
+              if (attributeNames.indexOf(bracketed) === -1) {
+                errors.add('Tag "' + tag + '" must have attribute "' + attribute + '"', lineNumber, columnNumber);
+              }
             }
           });
         } else {

--- a/test/rules/require-specific-attributes.test.js
+++ b/test/rules/require-specific-attributes.test.js
@@ -24,6 +24,10 @@ function createTest(linter, fixturesPath) {
         assert.equal(linter.checkString('img(alt=\'alt\')').length, 0);
       });
 
+      it('should not report existing bracketed attributes', function () {
+        assert.equal(linter.checkString('img([alt]=\'alt\')').length, 0);
+      });
+
       it('should report multiple errors found in file', function () {
         var result = linter.checkFile(fixturesPath + 'require-specific-attributes.pug');
 


### PR DESCRIPTION
For Angular projects there can be input binding using [attr].  These
should match attr when determing if the attribute is present.